### PR TITLE
meta content block to specify per page descriptions

### DIFF
--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Our Software Development Services"
+description = "Our Software Development Services"
 sort_by = "weight"
 
 [extra]

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
-    <meta name="description" content="{{ config.description }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="color-scheme" content="light dark" />
 
-    <title>{% block title %} {% endblock title %}</title>
+    {% block meta_content %} {% endblock meta_content %}
+
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/rss.xml" />
     <link rel="icon" type="image/png" href="{{ get_url(path="images/favicon.svg") }}" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.0.6/css/pico.min.css" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,8 +1,12 @@
 {% extends "base.html" %}
 
-{% block title%}
-  {{ config.title }}
-{% endblock title %}
+{% block meta_content %}
+  <title>{{ config.title }}</title>
+  <meta name="description" content="{{ config.description }}" />
+  
+  <meta property="og:title" content="{{ config.title }}" />
+  <meta property="og:description" content="{{ config.description }}" />
+{% endblock meta_content %}
 
 {% block content %}
 <main class="container">

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,8 +1,12 @@
 {% extends "base.html" %}
 
-{% block title%}
-  {{ page.title}} - {{ config.title }}
-{% endblock title %}
+{% block meta_content %}
+  <title>{{ page.title}} - {{ config.title }}</title>
+  <meta name="description" content="{{ page.description }} — {{ config.description }}" />
+  
+  <meta property="og:title" content="{{ page.title }} — {{ config.title }}" />
+  <meta property="og:description" content="{{ page.description }} — {{ config.description }}" />
+{% endblock meta_content %}
 
 {% block content %}
 <main class="container">

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,8 +1,12 @@
 {% extends "base.html" %}
 
-{% block title%}
-  {{ section.title}} - {{ config.title }}
-{% endblock title %}
+{% block meta_content %}
+  <title>{{ section.title}} - {{ config.title }}</title>
+  <meta name="description" content="{{ section.description }} — {{ config.description }}" />
+  
+  <meta property="og:title" content="{{ section.title }} — {{ config.title }}" />
+  <meta property="og:description" content="{{ section.description }} — {{ config.description }}" />
+{% endblock meta_content %}
 
 {% block content %}
 <main class="container">


### PR DESCRIPTION
Now you can add `description` to each markdown file so it gets placed into the header.