### PR TITLE
Update site name and add copyright config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 base_url = "https://limeleaf.io"
 title = "Limeleaf Worker Collective"
-copyright = "Limeleaf Worker Collective, LLC
+copyright = "Limeleaf Worker Collective, LLC"
 description = "Limeleaf is a software development cooperative that builds fresh, sustainable, simple tech solutions for businesses, social impact startups, and technologically underserved communities."
 
 generate_feed = true

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 base_url = "https://limeleaf.io"
-title = "Limeleaf Worker Collective, LLC."
+title = "Limeleaf Worker Collective"
+copyright = "Limeleaf Worker Collective, LLC
 description = "Limeleaf is a software development cooperative that builds fresh, sustainable, simple tech solutions for businesses, social impact startups, and technologically underserved communities."
 
 generate_feed = true

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
     {% block content %} {% endblock content %}
 
     <footer class="container">
-      <p>&copy; {{ now() | date(format="%Y") }} {{ config.title }}</p>
+      <p>&copy; {{ now() | date(format="%Y") }} {{ config.copyright }}</p>
       <p class="attribution"><a href="https://storyset.com" title="Storyset website">Site illustrations by Storyset</a> | <a href="{{ get_url(path="@/contact/privacy.md") }}" title="Limeleaf privacy policy">Privacy Policy</p>
       <nav>
         <a href="https://github.com/limeleaf-collective" alt="GitHub" title="GitHub"><i class="fa fa-github-square" aria-hidden="true"></i></a>


### PR DESCRIPTION
This changes the `config.title` to `Limeleaf Worker Collective`, which is how we colloquially refer to the company and adds `config.copyright` with a value of `Limeleaf Worker Collective, LLC`, which is used in the copyright section of the footer and how we legally refer to the company.